### PR TITLE
Configure Keycloak JWT decoder

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/SecurityConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/SecurityConfig.java
@@ -2,9 +2,12 @@ package ar.org.hospitalcuencaalta.api_gateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
 @Configuration
@@ -33,6 +36,11 @@ public class SecurityConfig {
             t.jwt(Customizer.withDefaults());
         });
         return http.build();
+    }
+
+    @Bean
+    public ReactiveJwtDecoder jwtDecoder(@Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}") String jwkSetUri) {
+        return NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri).build();
     }
 
 }

--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -308,3 +308,4 @@ logging.level.de.codecentric.boot.admin.client.registration=ERROR
 #   Seguridad
 # ---------------------------------
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://127.0.0.1:8081/realms/rrhh
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://127.0.0.1:8081/realms/rrhh/protocol/openid-connect/certs


### PR DESCRIPTION
## Summary
- configure reactive JWT decoder backed by Keycloak's JWK set
- add Keycloak security properties

## Testing
- `mvn -q -pl API-gateway -am test` *(fails: Non-resolvable parent POM for ar.org.hospitalcuencaalta:seguridad:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_689d0731294483248daddd0c7f49aa0f