### PR TITLE
Configure Keycloak JWT decoder

### DIFF
--- a/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/SecurityConfig.java
+++ b/API-gateway/src/main/java/ar/org/hospitalcuencaalta/api_gateway/config/SecurityConfig.java
@@ -11,20 +11,6 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 public class SecurityConfig {
 
-//    @Bean
-//    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
-//        http.csrf(ServerHttpSecurity.CsrfSpec::disable);
-//        http.authorizeExchange(exchange -> exchange.anyExchange().authenticated());
-//        http.oauth2ResourceServer(ServerHttpSecurity.OAuth2ResourceServerSpec::jwt);
-//        return http.build();
-//    }
-//
-//    @Bean
-//    public ReactiveJwtDecoder jwtDecoder() {
-//        return token -> Mono.error(new UnsupportedOperationException("No JWT decoder configured"));
-//    }
-
-
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
         http.csrf(ServerHttpSecurity.CsrfSpec::disable);

--- a/API-gateway/src/main/resources/application.properties
+++ b/API-gateway/src/main/resources/application.properties
@@ -308,3 +308,4 @@ logging.level.de.codecentric.boot.admin.client.registration=ERROR
 #   Seguridad
 # ---------------------------------
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://127.0.0.1:8081/realms/rrhh
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://127.0.0.1:8081/realms/rrhh/protocol/openid-connect/certs

--- a/API-gateway/src/test/resources/application.properties
+++ b/API-gateway/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 eureka.client.enabled=false
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://127.0.0.1:8081/realms/rrhh/protocol/openid-connect/certs


### PR DESCRIPTION
## Summary
- rely on Spring Security auto-configured JWT decoder and configure gateway to validate Keycloak-issued tokens
- declare Keycloak JWK set URI for test configuration

## Testing
- `mvn -q -pl API-gateway -am test` *(fails: Non-resolvable parent POM for ar.org.hospitalcuencaalta:seguridad:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d0731294483248daddd0c7f49aa0f